### PR TITLE
Fix phpstan failure in ApiExtension config assertion

### DIFF
--- a/src/DI/ApiExtension.php
+++ b/src/DI/ApiExtension.php
@@ -36,7 +36,7 @@ class ApiExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		$expectService = Expect::anyOf(
-			Expect::string()->required()->assert(fn ($input) => str_starts_with($input, '@') || class_exists($input) || interface_exists($input)),
+			Expect::string()->required()->assert(fn ($input) => is_string($input) && (str_starts_with($input, '@') || class_exists($input) || interface_exists($input))),
 			Expect::type(Statement::class)->required(),
 		);
 


### PR DESCRIPTION
## Summary
- Fixes the default-branch phpstan failure caused by passing an unconstrained `mixed` value into `str_starts_with`, `class_exists`, and `interface_exists` inside the config schema assertion.
- Adds an explicit `is_string()` guard in `ApiExtension::getConfigSchema()` so the assertion remains safe and statically provable.
- Verified locally with `make qa`, `make tests`, and `make coverage`.