### PR TITLE
Migrate Coveralls references to Codecov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align=center>
   <a href="https://github.com/contributte/api/actions"><img src="https://badgen.net/github/checks/contributte/api/master?cache=300"></a>
-  <a href="https://coveralls.io/r/contributte/api"> <img src="https://badgen.net/coveralls/c/github/contributte/api?cache=300"> </a>
+  <a href="https://codecov.io/gh/contributte/api"><img src="https://badgen.net/codecov/c/github/contributte/api"></a>
   <a href="https://packagist.org/packages/contributte/api"> <img src="https://badgen.net/packagist/dm/contributte/api"> </a>
   <a href="https://packagist.org/packages/contributte/api"> <img src="https://badgen.net/packagist/v/contributte/api"> </a>
 </p>


### PR DESCRIPTION
What changed
- replaced the README coverage badge and link with the Codecov variant used in newer Contributte packages
- verified the existing coverage workflow already uses the shared `nette-tester-coverage-v2` workflow, so no workflow changes were needed

Why
- completes the remaining Coveralls-to-Codecov migration for `contributte/api`
- keeps `contributte/api` aligned with contributte/contributte#72 and the current badge pattern used in `contributte/vite`