### PR TITLE
QA: replace phpdbg in coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- keep the existing coverage output split for GitHub Actions and local HTML generation

## Motivation

Issue #73 tracks removing `phpdbg` from Contributte coverage targets. This repo still used `phpdbg`, so the coverage target now matches the new `php`-based pattern.

## Changes

- update both `coverage` target variants in `Makefile` to run Tester with `php`

## Testing

- [x] `make tests`
- [ ] `make coverage` locally
- [ ] CI passes

Local coverage is currently blocked because this environment runs plain `php` without Xdebug, PCOV, or PHPDBG available for code coverage.